### PR TITLE
improved RegExs for xsd:dateTime

### DIFF
--- a/src/main/resources/OAConstraintsSPARQL.json
+++ b/src/main/resources/OAConstraintsSPARQL.json
@@ -140,20 +140,20 @@
       {
           "ref": "2.2.0. (4) Annotation Provenance",
           "url": "http://www.openannotation.org/spec/core/core.html#Provenance",
-          "description": "The datetime for oa:annotatedAt and oa:serializedAt MUST be expressed in the xsd:dateTime (ISO 8601) format.",
+          "description": "The datetime for oa:annotatedAt and oa:serializedAt MUST be expressed in the xsd:dateTime (ISO 8601) format: YYYY-MM-DDThh:mm:ss[.s][Z or -hh:mm or +hh:mm]",
           "severity": "error",
           "preconditionMessage": "oa:annotatedAt or oa:serializedAt property not present",
           "precondition": "PREFIX oa: <http://www.w3.org/ns/oa#> ASK WHERE {  {?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time}}",
-          "query": "PREFIX oa: <http://www.w3.org/ns/oa#> SELECT ?annotation ?time WHERE { {?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time} MINUS { {?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time} . FILTER regex(str(?time), \"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\")}}"
+          "query": "PREFIX oa: <http://www.w3.org/ns/oa#> SELECT ?annotation ?time WHERE { {?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time} MINUS { {?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time} . FILTER regex(str(?time), \"-?([1-9][0-9]{3,}|0[0-9]{3})-((0[13578]|1[02])-((0[1-9])|1[0-9]|2[0-9]|3[01])|(0[469]|11)-((0[1-9])|1[0-9]|2[0-9]|30)|(02)-((0[1-9])|1[0-9]|2[0-9]))T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\\\.[0-9]+)?|(24:00:00(\\\\.0+)?))(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?\")}}"
       },
       {
           "ref": "2.2.0. (5) Annotation Provenance",
           "url": "http://www.openannotation.org/spec/core/core.html#Provenance",
-          "description": "The datetime for oa:annotatedAt and oa:serializedAt SHOULD have a timezone specified, in the format YYYY-MM-DDThh:mm:ss[Z or -hh:mm:ss or +hh:mm:ss]",
+          "description": "The datetime for oa:annotatedAt and oa:serializedAt SHOULD have a timezone specified, in the format YYYY-MM-DDThh:mm:ss[.s][Z or -hh:mm or +hh:mm]",
           "severity": "warn",
           "preconditionMessage": "oa:annotatedAt or oa:serializedAt property not present",
           "precondition": "PREFIX oa: <http://www.w3.org/ns/oa#> ASK WHERE {  {?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time}}",
-          "query": "PREFIX oa: <http://www.w3.org/ns/oa#> SELECT ?annotation ?time WHERE {{?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time}  MINUS { {?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time} . FILTER regex(str(?time), \"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9](\\\\+[0-9][0-9]:[0-9][0-9]|-[0-9][0-9]:[0-9][0-9]|Z)\")}}"
+          "query": "PREFIX oa: <http://www.w3.org/ns/oa#> SELECT ?annotation ?time WHERE {{?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time}  MINUS { {?annotation oa:annotatedAt ?time} UNION {?annotation oa:serializedAt ?time} . FILTER regex(str(?time), \"-?([1-9][0-9]{3,}|0[0-9]{3})-((0[13578]|1[02])-((0[1-9])|1[0-9]|2[0-9]|3[01])|(0[469]|11)-((0[1-9])|1[0-9]|2[0-9]|30)|(02)-((0[1-9])|1[0-9]|2[0-9]))T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\\\.[0-9]+)?|(24:00:00(\\\\.0+)?))(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))\")}}"
       },
       {
           "ref": "2.2.0. (6) Annotation Provenance",
@@ -371,20 +371,20 @@
       {
           "ref": "3.3.1. (1) Time State",
           "url": "http://www.openannotation.org/spec/core/specific.html#TimeState",
-          "description": "The timestamp for oa:when MUST be expressed in the xsd:dateTime (ISO 8601) format.",
+          "description": "The timestamp for oa:when MUST be expressed in the xsd:dateTime (ISO 8601) format: YYYY-MM-DDThh:mm:ss[.s][Z or -hh:mm or +hh:mm]",
           "severity": "error",
           "preconditionMessage": "oa:when property not present",
           "precondition": "PREFIX oa: <http://www.w3.org/ns/oa#> ASK WHERE { ?timestate oa:when ?when }",
-          "query": "PREFIX oa: <http://www.w3.org/ns/oa#> SELECT * WHERE { ?timestate oa:when ?when . MINUS { ?timestate oa:when ?when .  FILTER regex(str(?when), \"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\")}}"
+          "query": "PREFIX oa: <http://www.w3.org/ns/oa#> SELECT * WHERE { ?timestate oa:when ?when . MINUS { ?timestate oa:when ?when .  FILTER regex(str(?when), \"-?([1-9][0-9]{3,}|0[0-9]{3})-((0[13578]|1[02])-((0[1-9])|1[0-9]|2[0-9]|3[01])|(0[469]|11)-((0[1-9])|1[0-9]|2[0-9]|30)|(02)-((0[1-9])|1[0-9]|2[0-9]))T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\\\.[0-9]+)?|(24:00:00(\\\\.0+)?))(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?\")}}"
       },
       {
           "ref": "3.3.1. (2) Time State",
           "url": "http://www.openannotation.org/spec/core/specific.html#TimeState",
-          "description": "The timestamp for oa:when SHOULD have a timezone specified, in the format YYYY-MM-DDThh:mm:ss[Z or -hh:mm:ss or +hh:mm:ss].",
+          "description": "The timestamp for oa:when SHOULD have a timezone specified, in the format YYYY-MM-DDThh:mm:ss[.s][Z or -hh:mm or +hh:mm].",
           "severity": "warn",
           "preconditionMessage": "oa:when property not present",
           "precondition": "PREFIX oa: <http://www.w3.org/ns/oa#> ASK WHERE { ?timestate oa:when ?when}",
-          "query": "PREFIX oa: <http://www.w3.org/ns/oa#> SELECT * WHERE { ?timestate oa:when ?when . MINUS { ?timestate oa:when ?when . FILTER regex(str(?when), \"[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9](\\\\+[0-9][0-9]:[0-9][0-9]|-[0-9][0-9]:[0-9][0-9]|Z)\")}}"
+          "query": "PREFIX oa: <http://www.w3.org/ns/oa#> SELECT * WHERE { ?timestate oa:when ?when . MINUS { ?timestate oa:when ?when . FILTER regex(str(?when), \"-?([1-9][0-9]{3,}|0[0-9]{3})-((0[13578]|1[02])-((0[1-9])|1[0-9]|2[0-9]|3[01])|(0[469]|11)-((0[1-9])|1[0-9]|2[0-9]|30)|(02)-((0[1-9])|1[0-9]|2[0-9]))T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\\\.[0-9]+)?|(24:00:00(\\\\.0+)?))(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))\")}}"
       },
       {
           "ref": "3.3.1. (3) Time State",


### PR DESCRIPTION
added improved regular expressions to check for xsd:dateTime in the checks: 2.2.0. (4) Annotation Provenance, 2.2.0. (5) Annotation Provenance, 3.3.1. (1) Time State and 3.3.1. (2) Time State. It uses the regular expression from http://www.w3.org/TR/xmlschema11-2/#dateTime with an additional improvement: The day of the month is now not just limited to 01-31 in general but is dependent on the month itself. (However for February the 29 is always as valid date according to the RegEx, since modeling the leap year rules in RegExs is impossible/really difficult).
For the checks 2.2.0. (5) and 3.3.1. (2) the time zone fragment is not optional.
For the checks 2.2.0. (4) and 3.3.1. (1) the time is now required (as specified by xsd:dateTime)
All of the checks now allow for fractions of a seconds (this would previously cause a warning, despite it being valid xsd:dateTime)
Additionally updated the documentations of the elements. For the checks 2.2.0. (4) and 3.3.1. (1) the allowed syntax is shown. For  the checks 2.2.0. (5) and 3.3.1. (2) the syntax does not show the seconds in the time zone anymore (it was not checked for it, nor should it have done this).
I hope this helps. We only noticed the problem, because 3.3.1. (1) would complain about incorrect time zone setting, but it was actually the fractions of the seconds that it didn't allow.
http://www.xkcd.com/208/ (Sorry, I couldn't resist)
